### PR TITLE
BUG: etc/slicer_parselogs: Fix reporting of version on stats dashboard

### DIFF
--- a/etc/slicer_parselogs/bitstream.py
+++ b/etc/slicer_parselogs/bitstream.py
@@ -50,9 +50,16 @@ def get_cleaned_up_record(record):
         }
 
     if getServerAPI() == ServerAPI.Girder_v1:
+        extension = {
+            "linux": ".tar.gz",
+            "macosx": ".dmg",
+            "win": ".exe",
+        }.get(record["meta"]["os"], "")
         return {
             'bitstream_id': record['_id'],
-            'filename': '',  # Not supported
+            'filename': (
+                f'{record["meta"]["baseName"]}-{record["meta"]["version"]}'
+                f'-{record["meta"]["os"]}-{record["meta"]["arch"]}{extension}'),
             'os': record['meta']['os'],
             'arch': record['meta']['arch'],
             'product_name': record['meta']['baseName'],


### PR DESCRIPTION
This commit ensures version can be properly extracted from the bitstream
details associated with Girder records by associating filename info. This allows to have version `5.0` and `5.1` to be listed.

In addition of implementing this change, the `download-stats.sqlite` database has also been manually patched to remove 4 records originally associated with custom applications (this explained the presence of the version of `1.2`)

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/219043/179091176-02808c78-bd6f-4afb-a659-c1afb531ca9a.png) | ![image](https://user-images.githubusercontent.com/219043/179090884-4c839d67-dbdf-4973-9c4e-a5140f05e504.png) |
