### PR TITLE
slicer_getbuildinfo: Update records to capture metadata changes

### DIFF
--- a/etc/slicer_getbuildinfo/__main__.py
+++ b/etc/slicer_getbuildinfo/__main__.py
@@ -54,7 +54,7 @@ def main(dbfile):
                     record TEXT)'''.format(primary_key_type=primary_key_type))
 
         cursor = db.cursor()
-        cursor.executemany('''insert or ignore into _
+        cursor.executemany('''insert or replace into _
             (item_id, revision, checkout_date, build_date, record)
             values(?,?,?,?,?)''',
                            [_f for _f in (recordToDb(r) for r in records) if _f])


### PR DESCRIPTION
This commit revisits the approach originally introduced in b3c786c3e changing the query from "insert or ignore" to "insert or replace". This will ensure updating metadata like `pre_release` are recorded in the database.