### PR TITLE
Add support for identifying and removing duplicate drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This section describes main files and directories available in this repository.
     | `backup-databases.sh`             | Archive databases as release assets associated with the [Slicer/slicer_download_database_backups](https://github.com/Slicer/slicer_download_database_backups/releases/tag/database-backups) private repository. |
     | `cron-getbuildinfo.sh`            | Invoke `etc/slicer_getbuildinfo` python application. |
     | `cron-parselogs.sh`               | Invoke `etc/slicer_parselogs` python application. |
+    | `display-duplicate-drafts.sh`     | Display duplicate draft folders & items from https://slicer-packages.kitware.com/. |
     | `download-fallback-databases.sh` | Download latest database backups from [database-backups][https://github.com/Slicer/slicer_download_database_backups/releases/tag/database-backups] release associated with `Slicer/slicer_download_database_backups` repository. |
     | `download-flask-templates-and-assets.sh` | Download up-to-date flask templates from [Slicer/slicer.org@download-slicer-org][branch-download-slicer-org] branch. |
     | `geoipupdate`                     | Download GeoIP Binary Databases into `etc/geoip/db` directory. |

--- a/bin/cron-getbuildinfo.sh
+++ b/bin/cron-getbuildinfo.sh
@@ -43,4 +43,4 @@ echo "[slicer_getbuildinfo] Using these directories"
 echo "  ROOT_DIR       : ${ROOT_DIR}"
 
 echo
-PYTHONPATH=${ROOT_DIR} "${PYTHON_EXECUTABLE}" "${ROOT_DIR}/etc/slicer_getbuildinfo" ${SLICER_DOWNLOAD_DB_FILE}
+PYTHONPATH=${ROOT_DIR} "${PYTHON_EXECUTABLE}" "${ROOT_DIR}/etc/slicer_getbuildinfo" $* ${SLICER_DOWNLOAD_DB_FILE}

--- a/bin/display-duplicate-drafts.sh
+++ b/bin/display-duplicate-drafts.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+
+ROOT_DIR=$(realpath "${script_dir}/..")
+VIRTUALENV_DIR=$(realpath -m "${ROOT_DIR}/env")
+PYTHON_EXECUTABLE=${VIRTUALENV_DIR}/bin/python
+
+# Customizing environment
+echo -n "[slicer_getbuildinfo] Looking for ${ROOT_DIR}/bin/.start_environment "
+if [ -e "${ROOT_DIR}/bin/.start_environment" ]; then
+  source "${ROOT_DIR}/bin/.start_environment"
+  echo "[ok]"
+else
+  echo "[not found]"
+fi
+
+# Configuration
+export SLICER_DOWNLOAD_SERVER_CONF="${SLICER_DOWNLOAD_SERVER_CONF:-${ROOT_DIR}/etc/conf/config.py}"
+if [ ! -e "${SLICER_DOWNLOAD_SERVER_CONF}" ]; then
+  echo "SLICER_DOWNLOAD_SERVER_CONF set to an nonexistent file: ${SLICER_DOWNLOAD_SERVER_CONF}"
+  exit 99
+fi
+
+# Set variables
+SLICER_DOWNLOAD_DEBUG=$(PYTHONPATH=${ROOT_DIR} ${PYTHON_EXECUTABLE} -c "import slicer_download_server as sds; print(sds.app.config['DEBUG'])")
+SLICER_DOWNLOAD_SERVER_API=$(PYTHONPATH=${ROOT_DIR} ${PYTHON_EXECUTABLE} -c "import slicer_download as sd; print(sd.getServerAPI().name)")
+
+# Display summary
+echo
+echo "[slicer_getbuildinfo] Using this config"
+echo "  SLICER_DOWNLOAD_SERVER_CONF: ${SLICER_DOWNLOAD_SERVER_CONF}"
+echo "  SLICER_DOWNLOAD_DEBUG      : ${SLICER_DOWNLOAD_DEBUG}"
+echo "  SLICER_DOWNLOAD_SERVER_API : ${SLICER_DOWNLOAD_SERVER_API}"
+echo
+echo "[slicer_getbuildinfo] Using these directories"
+echo "  ROOT_DIR       : ${ROOT_DIR}"
+
+echo
+PYTHONPATH=${ROOT_DIR} "${PYTHON_EXECUTABLE}" "${ROOT_DIR}/etc/slicer_getbuildinfo" --display-duplicate-drafts

--- a/etc/slicer_getbuildinfo/__main__.py
+++ b/etc/slicer_getbuildinfo/__main__.py
@@ -1,7 +1,7 @@
+import argparse
 import json
 import sqlite3
 import sys
-import textwrap
 
 from slicer_download import (
     getServerAPI,
@@ -37,7 +37,12 @@ def recordToDb(r):
     }[getServerAPI()](r)
 
 
-def main(dbfile):
+
+def main():
+    argparser = argparse.ArgumentParser(description="Download Slicer application package metadata and update sqlite database")
+    argparser.add_argument("dbfile", metavar="DB_FILE")
+    args = argparser.parse_args()
+    dbfile = args.dbfile
 
     print("ServerAPI is {0}: {1}".format(getServerAPI().name, getServerAPIUrl()))
 
@@ -65,13 +70,4 @@ def main(dbfile):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print(textwrap.dedent("""
-        Usage: %s DB_FILE
-
-          Download Slicer application package metadata and update sqlite database
-
-        """ % sys.argv[0]), file=sys.stderr)
-        sys.exit(1)
-
-    main(sys.argv[1])
+    main()

--- a/etc/slicer_getbuildinfo/__main__.py
+++ b/etc/slicer_getbuildinfo/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import requests
 import sqlite3
 import sys
 
@@ -37,14 +38,84 @@ def recordToDb(r):
     }[getServerAPI()](r)
 
 
+def collectDuplicates(records):
+    """Return a dictionnary of ``<revision>-<os>-<arch>`` to folderIDs.
+
+    .. note:: Each ``<revision>-<os>-<arch>`` key may be associated with two or more folderIDs.
+    """
+    assert getServerAPI() == ServerAPI.Girder_v1
+    packages = {}
+    for record in records:
+        key = "%s-%s-%s" % (record["meta"]["revision"], record["meta"]["os"], record["meta"]["arch"])
+        itemId = record["_id"]
+        folderId = record["folderId"]
+        if key not in packages:
+            packages[key] = [(itemId, folderId)]
+        else:
+            packages[key].append((itemId, folderId))
+
+    return {key: item_ids for key, item_ids in packages.items() if len(item_ids) > 1}
+
+
+def displayDuplicateDrafts(duplicates):
+    """Display table of duplicate ``<revision>-<os>-<arch>`` and correponding draft folder URLs
+    and draft item IDS.
+
+    Entries of the table are organized using the headers `<revision>-<os>-<arch>`, `release`, `itemId`
+    and `folderId` where `release` is displayed as `<DRAFT>` if no matching release was found.
+
+    The matching with a release is done by checking if the `folderId` associated with the
+    `<revision>-<os>-<arch>` item is found in the list of releases returned using
+    https://slicer-packages.kitware.com/api/v1/app/5f4474d0e1d8c75dfc705482/release?limit=0.
+    """
+    assert getServerAPI() == ServerAPI.Girder_v1
+    if len(duplicates) == 0:
+        print("")
+        print("No duplicate identified")
+        return
+
+    result = requests.get("{0}/app/5f4474d0e1d8c75dfc705482/release?limit=0".format(getServerAPIUrl()))
+    releases = {release["_id"]: release["name"] for release in result.json()}
+
+    draftItemIds = []
+    draftFolderIds = set()
+    print("")
+    print("|{:^24}|{:^9}|{:^26}|{:^26}|".format("`<revision>-<os>-<arch>`", "release", "itemId", "folderId"))
+    print(f"|{'-'*24}|{'-'*9}|{'-'*26}|{'-'*26}|")
+    for key, ids in duplicates.items():
+        for itemId, folderId in ids:
+            release  = releases.get(folderId, "`<DRAFT>`")
+            if folderId not in releases:
+                draftItemIds.append(itemId)
+                draftFolderIds.add(folderId)
+            print(f"|{key:<24}|{release:<9}|{itemId:<26}|{folderId:<26}|")
+
+    print("")
+    print("Duplicate draft folder URLs")
+    for folderId in draftFolderIds:
+        print(f"{getServerAPIUrl()[0:-len('api/v1/')]}/#folder/{folderId}")
+
+    print("")
+    print(f"Duplicate draft item IDs:\n{','.join(draftItemIds)}")
+
 
 def main():
     argparser = argparse.ArgumentParser(description="Download Slicer application package metadata and update sqlite database")
-    argparser.add_argument("dbfile", metavar="DB_FILE")
+    argparser.add_argument("--display-duplicate-drafts", action="store_true", help="Display duplicate draft folders & items and exit")
+    argparser.add_argument("dbfile", metavar="DB_FILE", nargs="?")
     args = argparser.parse_args()
     dbfile = args.dbfile
 
     print("ServerAPI is {0}: {1}".format(getServerAPI().name, getServerAPIUrl()))
+
+    if args.display_duplicate_drafts:
+        records = getRecordsFromURL()
+        duplicates = collectDuplicates(records)
+        displayDuplicateDrafts(duplicates)
+        sys.exit(0)
+
+    if dbfile is None:
+        argparser.error("No action requested, specify --display-duplicate-drafts or DB_FILE")
 
     records = getRecordsFromURL()
     print("Retrieved {0} records".format(len(records)))


### PR DESCRIPTION
* Add script `display-duplicate-drafts.sh` for identifying draft folders having a revision matching an existing release.
* Support running `./bin/cron-getbuildinfo.sh` by specifying `--remove-itemids item_id_1,item_id_2,..`

### Output associated with `display-duplicate-drafts.sh`

```
./bin/display-duplicate-drafts.sh 
[slicer_getbuildinfo] Looking for /home/jcfr/Projects/slicer_download/bin/.start_environment [ok]

[slicer_getbuildinfo] Using this config
  SLICER_DOWNLOAD_SERVER_CONF: /home/jcfr/Projects/slicer_download/etc/conf/config.py
  SLICER_DOWNLOAD_DEBUG      : True
  SLICER_DOWNLOAD_SERVER_API : Girder_v1

[slicer_getbuildinfo] Using these directories
  ROOT_DIR       : /home/jcfr/Projects/slicer_download

ServerAPI is Girder_v1: https://slicer-packages.kitware.com/api/v1

|`<revision>-<os>-<arch>`| release |          itemId          |         folderId         |
|------------------------|---------|--------------------------|--------------------------|
|31317-win-amd64         |5.2.1    |637f7a7f517443dc5dc73276  |637f77c6517443dc5dc7281f  |
|31317-win-amd64         |`<DRAFT>`|637f59de517443dc5dc70fb0  |637f38a6517443dc5dc6ff03  |
|31317-macosx-amd64      |5.2.1    |637f7a7f517443dc5dc73272  |637f77c6517443dc5dc7281f  |
|31317-macosx-amd64      |`<DRAFT>`|637f58c6517443dc5dc70f44  |637f38a6517443dc5dc6ff03  |
|31317-linux-amd64       |5.2.1    |637f7a7f517443dc5dc7326e  |637f77c6517443dc5dc7281f  |
|31317-linux-amd64       |`<DRAFT>`|637f38a7517443dc5dc6ff05  |637f38a6517443dc5dc6ff03  |
|31314-win-amd64         |5.2.0    |637f794b517443dc5dc7310d  |637e83a6517443dc5dc6bc13  |
|31314-win-amd64         |`<DRAFT>`|637cb0c4517443dc5dc5723a  |637c93f3517443dc5dc55eaf  |
|31314-macosx-amd64      |5.2.0    |637f794b517443dc5dc73109  |637e83a6517443dc5dc6bc13  |
|31314-macosx-amd64      |`<DRAFT>`|637cb320517443dc5dc575a8  |637c93f3517443dc5dc55eaf  |
|31314-linux-amd64       |5.2.0    |637e8639517443dc5dc6bc6f  |637e83a6517443dc5dc6bc13  |
|31314-linux-amd64       |`<DRAFT>`|637c93f4517443dc5dc55eb3  |637c93f3517443dc5dc55eaf  |
|30893-win-amd64         |5.0.3    |62d5d2ebe911182f1dc285b0  |62cc513eaa08d161a31c1372  |
|30893-win-amd64         |`<DRAFT>`|62c7fb6aaa08d161a319b428  |62c7dc49aa08d161a319a8f0  |
|30893-macosx-amd64      |5.0.3    |62cc8ff3aa08d161a31c260a  |62cc513eaa08d161a31c1372  |
|30893-macosx-amd64      |`<DRAFT>`|62c8000caa08d161a319b5d4  |62c7dc49aa08d161a319a8f0  |
|30893-linux-amd64       |5.0.3    |62cc52d2aa08d161a31c1af0  |62cc513eaa08d161a31c1372  |
|30893-linux-amd64       |`<DRAFT>`|62c7dc49aa08d161a319a8f2  |62c7dc49aa08d161a319a8f0  |
|30822-macosx-amd64      |5.0.2    |62871f83e8408647b39fedad  |6286cc6ee8408647b39f7e46  |
|30822-macosx-amd64      |`<DRAFT>`|6274f8c4e8408647b394e913  |6274d694e8408647b394d9d5  |
|30822-win-amd64         |5.0.2    |6286cf51e8408647b39f81c5  |6286cc6ee8408647b39f7e46  |
|30822-win-amd64         |`<DRAFT>`|6274f7fae8408647b394e892  |6274d694e8408647b394d9d5  |
|30822-linux-amd64       |5.0.2    |6286ce04e8408647b39f803a  |6286cc6ee8408647b39f7e46  |
|30822-linux-amd64       |`<DRAFT>`|6274d694e8408647b394d9d7  |6274d694e8408647b394d9d5  |

Duplicate draft folder URLs
https://slicer-packages.kitware.com/#folder/637c93f3517443dc5dc55eaf
https://slicer-packages.kitware.com/#folder/6274d694e8408647b394d9d5
https://slicer-packages.kitware.com/#folder/637f38a6517443dc5dc6ff03
https://slicer-packages.kitware.com/#folder/62c7dc49aa08d161a319a8f0


Duplicate draft item IDs:
637f59de517443dc5dc70fb0,637f58c6517443dc5dc70f44,637f38a7517443dc5dc6ff05,637cb0c4517443dc5dc5723a,637cb320517443dc5dc575a8,637c93f4517443dc5dc55eb3,62c7fb6aaa08d161a319b428,62c8000caa08d161a319b5d4,62c7dc49aa08d161a319a8f2,6274f8c4e8408647b394e913,6274f7fae8408647b394e892,6274d694e8408647b394d9d7
```