### PR TITLE
slicer_getbuildinfo: Gracefully handle itemId already removed or invalid

### DIFF
--- a/etc/slicer_getbuildinfo/__main__.py
+++ b/etc/slicer_getbuildinfo/__main__.py
@@ -178,11 +178,15 @@ def main():
                 packagesByItemId[itemId] = key
 
         with sqlite3.connect(dbfile) as db:
-            print(f"Removed {len(itemIdsToRemove)} rows")
+            print(f"Removing {len(itemIdsToRemove)} rows")
             for itemId in itemIdsToRemove:
+                if itemId not in packagesByItemId:
+                    print(f"  {itemId} (not found)")
+                    continue
                 db.execute("delete from _ where item_id=?", (itemId, ))
                 print(f"  {itemId} ({packagesByItemId[itemId]})")
             db.commit()
+            print(f"Removed {db.total_changes} rows")
 
         print("Saved {0}".format(dbfile))
 


### PR DESCRIPTION
This commit skips the the lookup of package key associated with itemId that are either already removed or invalid.

Example of output:

```
Removing 3 rows
  6385b966517443dc5dc97ce3 (not found)
  638596de517443dc5dc96a1c (31438-linux-amd64)
  6385b956517443dc5dc97cd0 (not found)
Removed 1 rows
Saved /home/jcfr/Projects/slicer_download/slicer_download_server/../etc/fallback/slicer-girder-records.sqlite
```