### PR TITLE
Fix macOS stats accounting for ua-parser updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This section describes main files and directories available in this repository.
     | `kill`                            | Shell script for killing the download Flask web application. |
     | `start`                           | Shell script for starting the download Flask web application. |
     | `stop`                            | Shell script for stopping the download Flask web application. |
+    | `update-database-useragent.sh`    | Update `uainfo` table re-parsing useragent strings. |
 
 [branch-download-slicer-org]: https://github.com/Slicer/slicer.org/tree/download-slicer-org
 

--- a/bin/cron-parselogs.sh
+++ b/bin/cron-parselogs.sh
@@ -52,5 +52,6 @@ exec "${PYTHON_EXECUTABLE}" "${ROOT_DIR}/etc/slicer_parselogs" \
     --db ${SLICER_DOWNLOAD_STATS_DB_FILE} \
     --geoip ${GEOIP_DB_FILE} \
     --statsdata ${SLICER_DOWNLOAD_STATS_DATA_FILE} \
+    $* \
     ${SLICER_DOWNLOAD_ACCESS_LOGS} \
     ${EXTRALOGS}

--- a/bin/update-database-useragent.sh
+++ b/bin/update-database-useragent.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+
+ROOT_DIR=$(realpath "${script_dir}/..")
+VIRTUALENV_DIR=$(realpath -m "${ROOT_DIR}/env")
+PYTHON_EXECUTABLE=${VIRTUALENV_DIR}/bin/python
+
+# Customizing environment
+echo -n "[slicer_getbuildinfo] Looking for ${ROOT_DIR}/bin/.start_environment "
+if [ -e "${ROOT_DIR}/bin/.start_environment" ]; then
+  source "${ROOT_DIR}/bin/.start_environment"
+  echo "[ok]"
+else
+  echo "[not found]"
+fi
+
+SLICER_DOWNLOAD_SERVER_API=$(PYTHONPATH=${ROOT_DIR} ${PYTHON_EXECUTABLE} -c "import slicer_download as sd; print(sd.getServerAPI().name)")
+
+SLICER_DOWNLOAD_STATS_DB_FILE="${ROOT_DIR}/var/download-stats.sqlite"
+
+SITE_LOG_DIR=${SITE_LOG_DIR:-$(realpath -m "${ROOT_DIR}/../logs/sites/slicer_download_org")}
+mkdir -p ${SITE_LOG_DIR}
+
+# Display summary
+echo
+echo "[slicer_parselogs] Using this config"
+echo "  SLICER_DOWNLOAD_SERVER_API       : ${SLICER_DOWNLOAD_SERVER_API}"
+echo "  SLICER_DOWNLOAD_STATS_DB_FILE    : ${SLICER_DOWNLOAD_STATS_DB_FILE}"
+echo
+echo "[slicer_parselogs] Using these directories"
+echo "  ROOT_DIR       : ${ROOT_DIR}"
+echo "  SITE_LOG_DIR   : ${SITE_LOG_DIR}"
+
+echo
+export PYTHONPATH=${ROOT_DIR}:${ROOT_DIR}/etc
+exec "${PYTHON_EXECUTABLE}" "${ROOT_DIR}/etc/slicer_parselogs" \
+    --db ${SLICER_DOWNLOAD_STATS_DB_FILE} \
+    --update-useragent-table \
+    $*

--- a/etc/slicer_parselogs/__main__.py
+++ b/etc/slicer_parselogs/__main__.py
@@ -26,8 +26,9 @@ def generate_slicer_stats(db, slicer_stats_data_file):
 def main():
     argparser = argparse.ArgumentParser(description='Process Slicer4 download information.')
     argparser.add_argument('--db', required=True, help="sqlite stats database")
-    argparser.add_argument('--geoip', required=True, help="geoip data file")
+    argparser.add_argument('--geoip', required=False, help="geoip data file")
     argparser.add_argument('--statsdata', required=True, help="slicer stats output")
+    argparser.add_argument('--only-statsdata', action='store_true', help="skip database update and only generate stats output")
     argparser.add_argument('--skip-records-fetch', action='store_true', help="skip fetching of records from packages server")
     argparser.add_argument('filenames', nargs="*")
     args = argparser.parse_args()
@@ -35,6 +36,21 @@ def main():
     geoip_filename = args.geoip
     filenames = args.filenames
     statsdata = args.statsdata
+
+    if args.only_statsdata:
+        if statsdata is None:
+            argparser.error('with --only-statsdata, the following arguments are required: --statsdata')
+
+        with openDb(dbname) as db:
+            generate_slicer_stats(db, statsdata)
+        sys.exit(0)
+
+    required_args = [
+        "--geoip",
+    ]
+
+    if any([vars(args).get(arg[2:]) is None for arg in required_args]):
+        argparser.error(f"the following arguments are required: {', '.join(required_args)}")
 
     with openDb(dbname) as db:
 

--- a/etc/slicer_parselogs/__main__.py
+++ b/etc/slicer_parselogs/__main__.py
@@ -27,9 +27,11 @@ def main():
     argparser = argparse.ArgumentParser(description='Process Slicer4 download information.')
     argparser.add_argument('--db', required=True, help="sqlite stats database")
     argparser.add_argument('--geoip', required=False, help="geoip data file")
-    argparser.add_argument('--statsdata', required=True, help="slicer stats output")
+    argparser.add_argument('--statsdata', required=False, help="slicer stats output")
     argparser.add_argument('--only-statsdata', action='store_true', help="skip database update and only generate stats output")
     argparser.add_argument('--skip-records-fetch', action='store_true', help="skip fetching of records from packages server")
+    argparser.add_argument('--update-useragent-table', action='store_true', help="update useragent table entries")
+    argparser.add_argument('--dry-run', action='store_true', help="simulate database update")
     argparser.add_argument('filenames', nargs="*")
     args = argparser.parse_args()
     dbname = args.db
@@ -45,8 +47,13 @@ def main():
             generate_slicer_stats(db, statsdata)
         sys.exit(0)
 
+    if args.update_useragent_table:
+        useragent.update_useragent_info(dbname, dry_run=args.dry_run)
+        sys.exit(0)
+
     required_args = [
         "--geoip",
+        "--statsdata",
     ]
 
     if any([vars(args).get(arg[2:]) is None for arg in required_args]):

--- a/etc/slicer_parselogs/useragent.py
+++ b/etc/slicer_parselogs/useragent.py
@@ -24,7 +24,7 @@ def get_browser_type_compat(rec):
 
     if family == 'Spider':
         return 'Robot'
-    if family == 'Other':
+    if family == 'Other' or family == "Mac":
         return 'Browser'
     return 'MobileBrowser'
 

--- a/etc/slicer_parselogs/useragent.py
+++ b/etc/slicer_parselogs/useragent.py
@@ -1,4 +1,9 @@
+import json
+import os
+from datetime import date
+
 from slicer_download import (
+    openDb,
     progress,
     progress_end
 )
@@ -67,3 +72,131 @@ def add_useragent_info(db):
         ua_completed.add(user_agent)
         db.commit() # commit per record in case we exit
     progress_end()
+
+
+def update_useragent_info(dbfile, dry_run=True):
+
+    if not os.path.isfile(dbfile):
+        print(f"Database file {dbfile} does not exist")
+        return
+
+    updated_rows_file = os.path.join(os.path.dirname(dbfile), f"download-stats-useragent-updates-{date.today()}.json")
+
+    with openDb(dbfile) as db:
+        print("update 'uainfo' table")
+
+        updatedRows = []
+
+        uas = list(db.execute("select useragent, browser_type, ua_name, os_name, os_family from uainfo"))
+        for index, ua in enumerate(uas, start=1):
+            progress(index, len(uas))
+            ua_fields = {key: ua[key] for key in ua.keys()}
+            updated_ua_fields = parse_useragent(ua[0]);
+            if updated_ua_fields is None:
+                continue
+
+            if ua_fields != updated_ua_fields:
+                updatedRows.append((ua_fields, updated_ua_fields))
+
+            if not dry_run:
+                add_useragent_info_row(db, updated_ua_fields)
+
+        progress_end()
+
+        if not dry_run:
+            db.commit()
+            print("Saved {0}".format(dbfile))
+
+        print(f"\nProcessed {index}/{len(uas)} rows")
+
+        with open(updated_rows_file, 'w+') as fp:
+            json.dump(updatedRows, fp, separators=(',', ':'), indent=2)
+
+        print(f"Written {updated_rows_file}")
+
+        if dry_run:
+            print("Dry-run successful! No actual changes were made.")
+
+        update_stats = read_useragent_info_update_stats(updated_rows_file)
+        display_useragent_info_update_stats(update_stats, field_details=True, useragent_details=False)
+
+
+def read_useragent_info_update_stats(update_file):
+    if not os.path.isfile(update_file):
+        print(f"Update file {update_file} does not exist")
+        return
+
+    per_field = {
+        "browser_type": [],
+        "ua_name": [],
+        "os_name": [],
+        "os_family": [],
+    }
+
+    with open(update_file) as fp:
+        update_data = json.load(fp)
+
+        for ua_fields, updated_ua_fields in update_data:
+            for field in per_field.keys():
+                value = ua_fields[field]
+                updated_value = updated_ua_fields[field]
+                if value != updated_value:
+                    per_field[field].append((value, updated_value, ua_fields["useragent"]))
+
+    per_field_count = {field: len(per_field[field]) for field in per_field}
+
+    per_field_changes = {}
+    for field in per_field.keys():
+        per_field_changes[field]= {}
+        for value, updated_value, useragent in per_field[field]:
+            per_field_changes[field].setdefault(value, []).append((updated_value, useragent))
+
+    return {"all": len(update_data), "count": {**per_field_count}, "changes": {**per_field_changes}}
+
+
+def display_useragent_info_update_stats(stats, field_details=False, useragent_details=False):
+
+    print(f"\nUpdated {stats['all']} rows")
+    for field in stats['count']:
+        print(f"- {stats['count'][field]} with `{field}` updated")
+
+    if field_details:
+
+        print("\n## Field updates")
+
+        for field in stats['changes']:
+            changes = stats['changes'][field]
+            print(f"\n<!-- {field} -->")
+
+            print(f"\n<details><summary>{field}</summary><pre>")
+            for value in changes:
+                updated_values = [value for value, _ in changes[value]]
+                updated_uas = [useragent for _, useragent in changes[value]]
+                for updated_value in set(updated_values):
+                    print(f"{value} -> {updated_value}: {updated_values.count(updated_value)}")
+            print("</pre></details>")
+
+    if useragent_details:
+
+        print("\n## User-agent updates")
+
+        selected_fields = ["browser_type"]
+
+        for field in stats['changes']:
+            changes = stats['changes'][field]
+            if field not in selected_fields:
+                continue
+
+            print(f"\n### {field}")
+
+            for value in changes:
+                updated_values = [value for value, _ in changes[value]]
+                updated_uas = [useragent for _, useragent in changes[value]]
+                for updated_value in set(updated_values):
+                    if field in selected_fields:
+                        section = f"{value} -> {updated_value}: {updated_values.count(updated_value)}"
+                        print(f"\n<!-- {section} -->")
+                        print(f"\n<details><summary>{section}</summary><pre>")
+                        for updated_ua in updated_uas:
+                            print(f"{updated_ua}")
+                        print("</pre></details>")


### PR DESCRIPTION
This updates the heuristic defining a user-agent string as "Browser" to account for the update of `ua-parser` version.

When the version of `ua-parser` was updated from `0.7.3` to `0.10.0` in f07920b43 (Refactor and improve system integration), the device information associated with user-agent strings like the one in the example below started to be parsed differently.

```python
from pprint import pprint as pp
from ua_parser import user_agent_parser

user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"
ua_rec = user_agent_parser.Parse(user_agent)
pp(ua_rec)

# using ua-parser==0.7.3
{'device': {'brand': None, 'family': 'Other', 'model': None},
[...]

# using ua-parser==0.10.0
{'device': {'brand': 'Apple', 'family': 'Mac', 'model': 'Mac'},
[...]
```

### Update of `uainfo` table & re-generation of download stats

To account for the behavior change of `ua-parser`, the `uainfo` table and download stats ave been updated following these steps:

1. Backup database

    ```bash
    $ ./bin/backup-databases.sh
    ...
    [backup_database] Using backup_prefix: 2023.10.20
    ...
    [backup_database] Uploading /tmp/tmp.hl47kCPxhS/2023.10.20_slicer-girder-records.sqlite
    ...
    [backup_database] Uploading /tmp/tmp.hl47kCPxhS/2023.10.20_slicer-download-data.json
    ...
    ```

2. Disable "slicer_parselogs" cronjob

3. Ensure requirements are up-to-date

    ```bash
    $ env/bin/python -m pip install -r requirements.txt
    ```

4. Simulate the table update specifying "--dry-run"

    ```bash
    $ ./bin/update-database-useragent.sh --dry-run
    
    [...]
    
    Processed 53160/53160 rows
    Written /home/kitware/download-slicer-org/slicer_download/var/download-stats-useragent-updates-2023-10-20.json
    Dry-run successful! No actual changes were made.
    
    Updated 35225 rows
     - 8488 with 'browser_type' updated
     - 19008 with 'ua_name' updated
     - 18024 with 'os_name' updated
     - 32729 with 'os_family' updated
    
    [browser_type]
      Browser -> MobileBrowser: 6438
      Browser -> Robot: 245
      MobileBrowser -> Browser: 1674
      Robot -> Browser: 131
    
    [...]
    ```

5. Perform the table update

    ```bash
    $ ./bin/update-database-useragent.sh
    
    [...]
    
    Saved /home/kitware/download-slicer-org/slicer_download/var/download-stats.sqlite
    
    Processed 53160/53160 rows
    Written /home/kitware/download-slicer-org/slicer_download/var/download-stats-useragent-updates-2023-10-20.json
    
    Updated 35225 rows
     - 8488 with 'browser_type' updated
     - 19008 with 'ua_name' updated
     - 18024 with 'os_name' updated
     - 32729 with 'os_family' updated
    
    [browser_type]
      Browser -> MobileBrowser: 6438
      Browser -> Robot: 245
      MobileBrowser -> Browser: 1674
      Robot -> Browser: 131
    
    [...]
    ```

6. Re-generate stats file

    ````bash
    $ ./bin/cron-parselogs.sh --only-statsdata
    [...[
    executing 'BitstreamQuery'
    executing 'AccessQuery'
    executing 'CountryCodeQuery'
    writing /home/kitware/download-slicer-org/slicer_download/var/slicer-download-data.json
    ````

7. Compare stats before and after

    |        | Before  | After   | Difference |
    |--------|---------|---------|------------|
    | all    | 1359941 | 1431726 |      71785 |
    | linux  |  168814 |  170934 |       2120 |
    | macosx |  200466 |  270589 |      70123 |
    | win    |  990661 |  990203 |       -458 |


Lastly, using an up-to-date parser also ensure that both newer system and as well as recent user agent reduction[^1] activities are handled.

[^1]: https://www.chromium.org/updates/ua-reduction/