### PR TITLE
slicer_parselogs: Remove redundant and obsolete requirements.txt

### DIFF
--- a/etc/slicer_parselogs/requirements.txt
+++ b/etc/slicer_parselogs/requirements.txt
@@ -1,7 +1,0 @@
-apache-log-parser==1.7.0
-geocoder==1.36.0
-geoip2==2.7.0
-maxminddb
-maxminddb-geolite2
-ua-parser==0.7.3
-user-agents==1.1.0


### PR DESCRIPTION
The "requirements.txt" file in slicer_parselogs directory was obsoleted by ea3773d (Add requirements and requirements-dev files).